### PR TITLE
Add sample on how to receive UART data

### DIFF
--- a/src/app_ble.c
+++ b/src/app_ble.c
@@ -86,7 +86,7 @@ rd_status_t on_scan_isr (const ri_comm_evt_t evt, void * p_data, // -V2009
 
         case RI_COMM_TIMEOUT:
             LOGD ("Timeout\r\n");
-            err_code |= app_ble_scan_start();
+            //err_code |= app_ble_scan_start();
             break;
 
         default:

--- a/src/app_uart.c
+++ b/src/app_uart.c
@@ -11,6 +11,7 @@
  *  Application UART control, processing incoming data and sending data out.
  */
 #include "app_config.h"
+#include "app_ble.h"
 #include "app_uart.h"
 #include "ruuvi_boards.h"
 #include "ruuvi_driver_error.h"
@@ -18,9 +19,21 @@
 #include "ruuvi_interface_communication.h"
 #include "ruuvi_interface_communication_ble_advertising.h"
 #include "ruuvi_interface_communication_uart.h"
+#include "ruuvi_interface_log.h"
+#include "ruuvi_interface_scheduler.h"
 
 #include <string.h>
 #include <stdio.h>
+
+static inline void LOG (const char * msg)
+{
+    ri_log (RI_LOG_LEVEL_INFO, msg);
+}
+
+static inline void LOGD (const char * msg)
+{
+    ri_log (RI_LOG_LEVEL_DEBUG, msg);
+}
 
 static ri_comm_channel_t m_uart; //!< UART communication interface.
 
@@ -47,15 +60,62 @@ static ri_uart_baudrate_t rb_to_ri_baud (const uint32_t rb_baud)
     return baud;
 }
 
+
+void uart_handler (void * p_event_data, uint16_t event_size)
+{
+    rd_status_t err_code = RD_SUCCESS;
+    ri_comm_message_t msg = {0};
+    msg.data_length = sizeof (msg.data);
+    err_code |= m_uart.read (&msg);
+    // Handle data in &msg.data. Note that data might be fragmented,
+    // the payload might contain `\n` and message has to be assembled from
+    // several fragments.
+    LOG ("RECEIVED: ");
+    ri_log_hex (RI_LOG_LEVEL_INFO,
+                msg.data,
+                msg.data_length);
+    LOG ("\n");
+    err_code |= app_ble_scan_start();
+}
+
+static rd_status_t uart_isr (ri_comm_evt_t evt,
+                             void * p_data, size_t data_len)
+{
+    switch (evt)
+    {
+        case RI_COMM_CONNECTED:
+            // Will never trigger on UART
+            break;
+
+        case RI_COMM_DISCONNECTED:
+            // Will never trigger on UART
+            break;
+
+        case RI_COMM_SENT:
+            LOGD ("Data sent\r\n");
+            break;
+
+        case RI_COMM_RECEIVED:
+            LOG ("Data received\r\n");
+            ri_scheduler_event_put (NULL, 0, &uart_handler);
+            break;
+
+        default:
+            break;
+    }
+
+    return RD_SUCCESS;
+}
+
 static void setup_uart_init (ri_uart_init_t * const p_init)
 {
     // Ruuvi board pin definitions are compatible with
     // Ruuvi driver pin definitions.
 #if APP_USBUART_ENABLED
-    p_init->hwfc_enabled = RB_UART_USB_HWFC_ENABLED;
+    p_init->hwfc_enabled = false;
     p_init->parity_enabled = RB_UART_USB_PARITY_ENABLED;
-    p_init->cts = RB_UART_USB_CTS_PIN;
-    p_init->rts = RB_UART_USB_RTS_PIN;
+    p_init->cts = RI_GPIO_ID_UNUSED;
+    p_init->rts = RI_GPIO_ID_UNUSED;
     p_init->tx = RB_UART_USB_TX_PIN;
     p_init->rx = RB_UART_USB_RX_PIN;
     p_init->baud = rb_to_ri_baud (RB_UART_BAUDRATE);
@@ -80,6 +140,7 @@ rd_status_t app_uart_init (void)
     if (RD_SUCCESS == err_code)
     {
         err_code |= ri_uart_config (&config);
+        m_uart.on_evt = &uart_isr;
     }
 
     return err_code;


### PR DESCRIPTION
A sample on how to receive data from UART with Interrupt and schedule processing the data. 

Note: Data coming from the gateway is binary, and may contain `0x0A` in payload. UART driver interprets it as the end of message and triggers a message received interrupt. In such cases, the message must be assembled from several fragments, similar to https://github.com/ruuvi/ruuvi.gateway_esp.c/blob/d1bca2131936ffbb861c32967ead9560e2fb597a/main/uart.c#L239 . 
The assembly logic could be unified into one file (ruuvi.endpoints.c/ca_uart.c?) 

Note: Current transmission end in ruuvi.endpoints.c/ca_uart.c is accidentally `0x12`, which does not trigger the UART driver message received interrupt. The endpoint should be refactored to use `0x0A` instead. 

Note: HWFC didn't work on my PC / CoolTerm with PCA10040 USB-UART converter, so it's disabled in this PR. 

This pull request is not intended to be merged as-is, it's only a sample for receiving data from host. 