### PR TITLE
Fix doxygen generation, PVS Studio check, using NULL pointers after failed dequeue

### DIFF
--- a/.github/workflows/gh-pages-check.yml
+++ b/.github/workflows/gh-pages-check.yml
@@ -25,17 +25,15 @@ jobs:
 
 
     # Install Doxygen
-    - name: Install Doxygen
-      run: sudo apt-get install -qq doxygen 
-
-    # Generate doxygen
-    - name: Generate docs
-      run: doxygen
+    uses: mattnotmitt/doxygen-action@v1
+    with:
+      working-directory: '.'
+      doxyfile-path: 'Doxyfile'
 
     # Error if doxygen.error has content
     - name: Check documentation has no errors
       run: |
-          if [[ $(wc -l <doxygen.error) -gt 0 ]]
+          if [[ $(wc -l < doxygen.error) -gt 0 ]]
           then
               cat doxygen.error
               exit 1

--- a/.github/workflows/gh-pages-check.yml
+++ b/.github/workflows/gh-pages-check.yml
@@ -24,11 +24,12 @@ jobs:
       uses: textbook/git-checkout-submodule-action@2.1.1
 
 
-    # Install Doxygen
-    uses: mattnotmitt/doxygen-action@v1
-    with:
-      working-directory: '.'
-      doxyfile-path: 'Doxyfile'
+    # Generate Dox
+    - name: Generate dox 
+      uses: mattnotmitt/doxygen-action@v1
+        with:
+          working-directory: '.'
+          doxyfile-path: 'Doxyfile'
 
     # Error if doxygen.error has content
     - name: Check documentation has no errors

--- a/.github/workflows/gh-pages-push.yml
+++ b/.github/workflows/gh-pages-push.yml
@@ -1,13 +1,11 @@
 # This is a basic workflow to help you get started with Actions
 
-name: GH-Pages
+name: GH-Pages-Deploy
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch
 on:
   push:
-    branches: [ master ]
-  pull_request:
     branches: [ master ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel

--- a/.github/workflows/pvs-check.yml
+++ b/.github/workflows/pvs-check.yml
@@ -23,6 +23,10 @@ jobs:
     - name: Checkout submodules
       uses: textbook/git-checkout-submodule-action@2.1.1
 
+    # Generate folder for PVS report
+    - name: mkdir
+      run: mkdir -p doxygen/html
+
     - name: Install PVS Studio
       run: |
           wget -q -O - https://files.viva64.com/etc/pubkey.txt | sudo apt-key add -

--- a/.github/workflows/pvs-check.yml
+++ b/.github/workflows/pvs-check.yml
@@ -23,15 +23,6 @@ jobs:
     - name: Checkout submodules
       uses: textbook/git-checkout-submodule-action@2.1.1
 
-
-    # Install Doxygen
-    - name: Install Doxygen
-      run: sudo apt-get install -qq doxygen 
-
-    # Generate doxygen folder to put PVS data in
-    - name: mkdir
-      run: mkdir -p doxygen/html
-
     - name: Install PVS Studio
       run: |
           wget -q -O - https://files.viva64.com/etc/pubkey.txt | sudo apt-key add -
@@ -46,13 +37,8 @@ jobs:
     # Error if pvs.error has content
     - name: Check PVS has no errors
       run: |
-          if [[ $(wc -l <doxygen.error) -gt 1 ]]
+          if [[ $(wc -l < pvs.error) -gt 1 ]]
           then
               cat pvs.error
               exit 1
           fi
-
-    - name: Install SSH Client 🔑
-      uses: webfactory/ssh-agent@v0.2.0
-      with:
-          ssh-private-key: ${{ secrets.DEPLOY_KEY }}

--- a/Makefile
+++ b/Makefile
@@ -256,7 +256,7 @@ pvs: $(SOURCES) $(EXECUTABLE)
 $(EXECUTABLE): $(OBJECTS)
 # Converting
 	plog-converter -a 'GA:1,2,3;OP:1,2,3;CS:1,2,3;MISRA:1,2,3' -t $(LOG_FORMAT) $(POBJECTS) -o $(PVS_LOG)
-	plog-converter -a 'GA:1,2,3;OP:1,2,3;CS:1,2,3;MISRA:1,2,3' -t errorfile $(POBJECTS) -o ./pvs.error
+	plog-converter -a 'GA:1;OP:1;CS:1;MISRA:1' -t errorfile $(POBJECTS) -o ./pvs.error
 
 sonar: $(SOURCES) $(SONAR) 
 $(SONAR): $(ANALYSIS)

--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 Ruuvi Gateway nRF52 code
 
 [![Build Status](https://travis-ci.org/ruuvi/ruuvi.gateway_nrf.c.svg?branch=master)](https://travis-ci.org/ruuvi/ruuvi.gateway_nrf.c)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=ruuvi_ruuvi.gateway_nrf.c&metric=alert_status)](https://sonarcloud.io/dashboard?id=ruuvi_ruuvi.gateway_nrf.c)
-[![Bugs](https://sonarcloud.io/api/project_badges/measure?project=ruuvi_ruuvi.gateway_nrf.c&metric=bugs)](https://sonarcloud.io/dashboard?id=ruuvi_ruuvi.gateway_nrf.c)
-[![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=ruuvi_ruuvi.gateway_nrf.c&metric=code_smells)](https://sonarcloud.io/dashboard?id=ruuvi_ruuvi.gateway_nrf.c)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=ruuvi_ruuvi.gateway_nrf.c&metric=coverage)](https://sonarcloud.io/dashboard?id=ruuvi_ruuvi.gateway_nrf.c)
-[![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=ruuvi_ruuvi.gateway_nrf.c&metric=duplicated_lines_density)](https://sonarcloud.io/dashboard?id=ruuvi_ruuvi.gateway_nrf.c)
-[![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=ruuvi_ruuvi.gateway_nrf.c&metric=ncloc)](https://sonarcloud.io/dashboard?id=ruuvi_ruuvi.gateway_nrf.c)
-[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=ruuvi_ruuvi.gateway_nrf.c&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=ruuvi_ruuvi.gateway_nrf.c)
-[![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=ruuvi_ruuvi.gateway_nrf.c&metric=reliability_rating)](https://sonarcloud.io/dashboard?id=ruuvi_ruuvi.gateway_nrf.c)
-[![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=ruuvi_ruuvi.gateway_nrf.c&metric=sqale_index)](https://sonarcloud.io/dashboard?id=ruuvi_ruuvi.gateway_nrf.c)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=ruuvi.gateway_nrf.c.c&metric=alert_status)](https://sonarcloud.io/dashboard?id=ruuvi.gateway_nrf.c.c)
+[![Bugs](https://sonarcloud.io/api/project_badges/measure?project=ruuvi.gateway_nrf.c.c&metric=bugs)](https://sonarcloud.io/dashboard?id=ruuvi.gateway_nrf.c.c)
+[![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=ruuvi.gateway_nrf.c.c&metric=code_smells)](https://sonarcloud.io/dashboard?id=ruuvi.gateway_nrf.c.c)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=ruuvi.gateway_nrf.c.c&metric=coverage)](https://sonarcloud.io/dashboard?id=ruuvi.gateway_nrf.c.c)
+[![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=ruuvi.gateway_nrf.c.c&metric=duplicated_lines_density)](https://sonarcloud.io/dashboard?id=ruuvi.gateway_nrf.c.c)
+[![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=ruuvi.gateway_nrf.c.c&metric=ncloc)](https://sonarcloud.io/dashboard?id=ruuvi.gateway_nrf.c.c)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=ruuvi.gateway_nrf.c.c&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=ruuvi.gateway_nrf.c.c)
+[![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=ruuvi.gateway_nrf.c.c&metric=reliability_rating)](https://sonarcloud.io/dashboard?id=ruuvi.gateway_nrf.c.c)
+[![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=ruuvi.gateway_nrf.c.c&metric=sqale_index)](https://sonarcloud.io/dashboard?id=ruuvi.gateway_nrf.c.c)
 
 # Setting up
 ## SDK 15.3
@@ -44,7 +44,7 @@ Make runs PVS Studio scan and outputs results under doxygen/html/fullhtml.
 This results into hundreds of warnings, it is up to you to filter the data you're interested in. For example you probably want to filter out warnings related to 64-bit systems. 
 
 ### Sonar scan
-Travis pushes the results to [SonarCloud.IO](https://sonarcloud.io/dashboard?id=ruuvi_ruuvi.gateway_nrf.c).
+Travis pushes the results to [SonarCloud.IO](https://sonarcloud.io/dashboard?id=ruuvi.gateway_nrf.c.c).
 SonarCloud uses access token which is private to Ruuvi, you'll need to fork the project and setup
 the SonarCloud under your own account if you wish to run Sonar Scan on your own code.
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,76 @@
 # ruuvi.gateway_nrf.c
 Ruuvi Gateway nRF52 code
 
+[![Build Status](https://travis-ci.org/ruuvi/ruuvi.gateway_nrf.c.svg?branch=master)](https://travis-ci.org/ruuvi/ruuvi.gateway_nrf.c)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=ruuvi_ruuvi.gateway_nrf.c&metric=alert_status)](https://sonarcloud.io/dashboard?id=ruuvi_ruuvi.gateway_nrf.c)
+[![Bugs](https://sonarcloud.io/api/project_badges/measure?project=ruuvi_ruuvi.gateway_nrf.c&metric=bugs)](https://sonarcloud.io/dashboard?id=ruuvi_ruuvi.gateway_nrf.c)
+[![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=ruuvi_ruuvi.gateway_nrf.c&metric=code_smells)](https://sonarcloud.io/dashboard?id=ruuvi_ruuvi.gateway_nrf.c)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=ruuvi_ruuvi.gateway_nrf.c&metric=coverage)](https://sonarcloud.io/dashboard?id=ruuvi_ruuvi.gateway_nrf.c)
+[![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=ruuvi_ruuvi.gateway_nrf.c&metric=duplicated_lines_density)](https://sonarcloud.io/dashboard?id=ruuvi_ruuvi.gateway_nrf.c)
+[![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=ruuvi_ruuvi.gateway_nrf.c&metric=ncloc)](https://sonarcloud.io/dashboard?id=ruuvi_ruuvi.gateway_nrf.c)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=ruuvi_ruuvi.gateway_nrf.c&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=ruuvi_ruuvi.gateway_nrf.c)
+[![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=ruuvi_ruuvi.gateway_nrf.c&metric=reliability_rating)](https://sonarcloud.io/dashboard?id=ruuvi_ruuvi.gateway_nrf.c)
+[![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=ruuvi_ruuvi.gateway_nrf.c&metric=sqale_index)](https://sonarcloud.io/dashboard?id=ruuvi_ruuvi.gateway_nrf.c)
+
 # Setting up
- - Unzip or softlink nRF5_SDK_15.3.0_59ac345 to the root of project
+## SDK 15.3
+Download [Nordic SDK15.3](https://developer.nordicsemi.com/nRF5_SDK/nRF5_SDK_v15.x.x/) and install it at the project root.
+If you're working on multiple nRF projects, you can (and should) use softlinking instead.
 
-IO pins:
+## Submodules
+Run `git submodule update --init --recursive`. This will search for and install the other git repositories referenced by this project. If any of the submodules has a changed remote, you'll need to run `git submodule sync --recursive` and again `git submodule update --init --recursive` to update the modules from new remotes. 
 
-Led:
+## Toolchain
+ARMGCC is used for [Jenkins builds](http://jenkins.ruuvi.com/job/ruuvi.gateway_nrf.c/), it's recommended to use SES for developing.
+ 
+Segger Embedded Studio can be set up by installing [nRF Connect for Desktop](https://www.nordicsemi.com/?sc_itemid=%7BB935528E-8BFA-42D9-8BB5-83E2A5E1FF5C%7D) 
+and following Getting Started plugin instructions.
+
+Start SES and open `ruuvi.gateway_nrf.c.emProject` in `src` directory, each of the target boards is in their own project.
+
+## Code style
+Code is formatted with [Artistic Style](http://astyle.sourceforge.net). 
+Run `astyle --project=.astylerc ./target_file`.
+
+## Static analysis
+The code can be checked with PVS Studio and Sonarcloud for some common errors, style issues and potential problems. [Here](https://ruuvi.github.io/ruuvi.gateway_nrf.c/fullhtml/index.html) is a link to generated report which gets pushed to GitHub.
+
+
+### PVS
+Obtain license and software from [Viva64](https://www.viva64.com/en/pvs-studio/).
+
+Make runs PVS Studio scan and outputs results under doxygen/html/fullhtml. 
+
+This results into hundreds of warnings, it is up to you to filter the data you're interested in. For example you probably want to filter out warnings related to 64-bit systems. 
+
+### Sonar scan
+Travis pushes the results to [SonarCloud.IO](https://sonarcloud.io/dashboard?id=ruuvi_ruuvi.gateway_nrf.c).
+SonarCloud uses access token which is private to Ruuvi, you'll need to fork the project and setup
+the SonarCloud under your own account if you wish to run Sonar Scan on your own code.
+
+# Running unit tests
+## Ceedling
+Unit tests are implemented with Ceedling. Run the tests with
+`ceedling test:all`
+
+# Builds
+Builds are in the Github [project releases](https://github.com/ruuvi/ruuvi.gateway_nrf.c/releases).
+
+# Developing Ruuvi Firmware
+## Compiling with SES
+Double click to select project: `pca10040` or `ruuvigw_nrf`. 
+Select the confuguaration used to build the project. For `ruuvigw_nrf` only `Release` version buildable.
+Press `F7` to build and `F5` for debug, or select `Build` and `Debug` in menu.
+
+## Compiling with ARMGCC
+Run `make` in `src` directory to build all the sources. 
+Run `make clean` in `src` directory to clean current build.
+
+# Flashing
+## With nrfjprog
+How to program nRF5x SoCs with nrfjprog you can find [Nordic Infocenter](https://infocenter.nordicsemi.com/index.jsp?topic=%2Fug_nrf5x_cltools%2FUG%2Fcltools%2Fnrf5x_nrfjprogexe.html).To get started:
 ```
-#define LED_PIN 29
-```
-Uart:
-```
-#define RX_PIN_NUMBER  11
-#define TX_PIN_NUMBER  12
+nrfjprog --eraseall
+nrfjprog --program ruuvigw_nrf_armgcc_ruuvigw_release_vX.X.X_full.hex
+nrfjprog --reset
 ```

--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 Ruuvi Gateway nRF52 code
 
 [![Build Status](https://travis-ci.org/ruuvi/ruuvi.gateway_nrf.c.svg?branch=master)](https://travis-ci.org/ruuvi/ruuvi.gateway_nrf.c)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=ruuvi.gateway_nrf.c.c&metric=alert_status)](https://sonarcloud.io/dashboard?id=ruuvi.gateway_nrf.c.c)
-[![Bugs](https://sonarcloud.io/api/project_badges/measure?project=ruuvi.gateway_nrf.c.c&metric=bugs)](https://sonarcloud.io/dashboard?id=ruuvi.gateway_nrf.c.c)
-[![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=ruuvi.gateway_nrf.c.c&metric=code_smells)](https://sonarcloud.io/dashboard?id=ruuvi.gateway_nrf.c.c)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=ruuvi.gateway_nrf.c.c&metric=coverage)](https://sonarcloud.io/dashboard?id=ruuvi.gateway_nrf.c.c)
-[![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=ruuvi.gateway_nrf.c.c&metric=duplicated_lines_density)](https://sonarcloud.io/dashboard?id=ruuvi.gateway_nrf.c.c)
-[![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=ruuvi.gateway_nrf.c.c&metric=ncloc)](https://sonarcloud.io/dashboard?id=ruuvi.gateway_nrf.c.c)
-[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=ruuvi.gateway_nrf.c.c&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=ruuvi.gateway_nrf.c.c)
-[![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=ruuvi.gateway_nrf.c.c&metric=reliability_rating)](https://sonarcloud.io/dashboard?id=ruuvi.gateway_nrf.c.c)
-[![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=ruuvi.gateway_nrf.c.c&metric=sqale_index)](https://sonarcloud.io/dashboard?id=ruuvi.gateway_nrf.c.c)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=ruuvi.gateway_nrf.c&metric=alert_status)](https://sonarcloud.io/dashboard?id=ruuvi.gateway_nrf.c)
+[![Bugs](https://sonarcloud.io/api/project_badges/measure?project=ruuvi.gateway_nrf.c&metric=bugs)](https://sonarcloud.io/dashboard?id=ruuvi.gateway_nrf.c)
+[![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=ruuvi.gateway_nrf.c&metric=code_smells)](https://sonarcloud.io/dashboard?id=ruuvi.gateway_nrf.c)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=ruuvi.gateway_nrf.c&metric=coverage)](https://sonarcloud.io/dashboard?id=ruuvi.gateway_nrf.c)
+[![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=ruuvi.gateway_nrf.c&metric=duplicated_lines_density)](https://sonarcloud.io/dashboard?id=ruuvi.gateway_nrf.c)
+[![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=ruuvi.gateway_nrf.c&metric=ncloc)](https://sonarcloud.io/dashboard?id=ruuvi.gateway_nrf.c)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=ruuvi.gateway_nrf.c&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=ruuvi.gateway_nrf.c)
+[![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=ruuvi.gateway_nrf.c&metric=reliability_rating)](https://sonarcloud.io/dashboard?id=ruuvi.gateway_nrf.c)
+[![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=ruuvi.gateway_nrf.c&metric=sqale_index)](https://sonarcloud.io/dashboard?id=ruuvi.gateway_nrf.c)
 
 # Setting up
 ## SDK 15.3
@@ -44,7 +44,7 @@ Make runs PVS Studio scan and outputs results under doxygen/html/fullhtml.
 This results into hundreds of warnings, it is up to you to filter the data you're interested in. For example you probably want to filter out warnings related to 64-bit systems. 
 
 ### Sonar scan
-Travis pushes the results to [SonarCloud.IO](https://sonarcloud.io/dashboard?id=ruuvi.gateway_nrf.c.c).
+Travis pushes the results to [SonarCloud.IO](https://sonarcloud.io/dashboard?id=ruuvi.gateway_nrf.c).
 SonarCloud uses access token which is private to Ruuvi, you'll need to fork the project and setup
 the SonarCloud under your own account if you wish to run Sonar Scan on your own code.
 

--- a/project.yml
+++ b/project.yml
@@ -16,14 +16,17 @@
   :default_tasks:
     - test:all
 
+
+        
 :flags:
   :test:
     :compile:
       :*:
-        - -Wall
-        - -Wno-tautological-pointer-compare # Cmock may create these, so ignore
-        - -Werror
-        - -std=c99
+        - -std=c11
+  :gcov:
+    :compile:
+      :*:
+        - -std=c11
 
 :environment:
 

--- a/project.yml
+++ b/project.yml
@@ -16,12 +16,14 @@
   :default_tasks:
     - test:all
 
-#:test_build:
-#  :use_assembly: TRUE
-
-#:release_build:
-#  :output: MyApp.out
-#  :use_assembly: FALSE
+:flags:
+  :test:
+    :compile:
+      :*:
+        - -Wall
+        - -Wno-tautological-pointer-compare # Cmock may create these, so ignore
+        - -Werror
+        - -std=c99
 
 :environment:
 

--- a/src/app_uart.c
+++ b/src/app_uart.c
@@ -167,20 +167,17 @@ void app_uart_parser (void * p_data, uint16_t data_len)
 
     if (RD_SUCCESS == err_code)
     {
-        if (false == rl_ringbuffer_empty (&m_uart_ring_buffer))
+        do
         {
-            do
-            {
-                uint8_t * p_dequeue_data = NULL;
-                status = rl_ringbuffer_dequeue (&m_uart_ring_buffer,
-                                                &p_dequeue_data);
+            uint8_t * p_dequeue_data = NULL;
+            status = rl_ringbuffer_dequeue (&m_uart_ring_buffer,
+                                            &p_dequeue_data);
 
-                if (NULL != p_dequeue_data)
-                {
-                    dequeue_data[index++] = *p_dequeue_data;
-                }
-            } while (RL_SUCCESS == status);
-        }
+            if (NULL != p_dequeue_data)
+            {
+                dequeue_data[index++] = *p_dequeue_data;
+            }
+        } while (RL_SUCCESS == status);
     }
     else
     {

--- a/src/app_uart.c
+++ b/src/app_uart.c
@@ -171,10 +171,14 @@ void app_uart_parser (void * p_data, uint16_t data_len)
         {
             do
             {
-                uint8_t * p_dequeue_data;
+                uint8_t * p_dequeue_data = NULL;
                 status = rl_ringbuffer_dequeue (&m_uart_ring_buffer,
                                                 &p_dequeue_data);
-                dequeue_data[index++] = *p_dequeue_data;
+
+                if (NULL != p_dequeue_data)
+                {
+                    dequeue_data[index++] = *p_dequeue_data;
+                }
             } while (RL_SUCCESS == status);
         }
     }
@@ -192,10 +196,14 @@ void app_uart_parser (void * p_data, uint16_t data_len)
 
         do
         {
-            uint8_t * p_dequeue_data;
+            uint8_t * p_dequeue_data = NULL;
             status = rl_ringbuffer_dequeue (&m_uart_ring_buffer,
                                             &p_dequeue_data);
-            dequeue_data[index++] = *p_dequeue_data;
+
+            if (NULL != p_dequeue_data)
+            {
+                dequeue_data[index++] = *p_dequeue_data;
+            }
         } while (RL_SUCCESS == status);
 
         err_code = re_ca_uart_decode ( (uint8_t *) dequeue_data, &uart_payload);

--- a/src/app_uart.c
+++ b/src/app_uart.c
@@ -187,7 +187,7 @@ void app_uart_parser (void * p_data, uint16_t data_len)
     ri_comm_message_t msg = {0};
     re_ca_uart_payload_t uart_payload = {0};
     uint8_t dequeue_data[APP_UART_RING_DEQ_BUFFER_MAX_LEN] = {0};
-    rl_status_t status;
+    rl_status_t status = RL_SUCCESS;
     size_t index = 0;
     err_code = re_ca_uart_decode ( (uint8_t *) p_data, &uart_payload);
 

--- a/src/app_uart.c
+++ b/src/app_uart.c
@@ -210,7 +210,7 @@ void app_uart_parser (void * p_data, uint16_t data_len)
 
         if (RD_SUCCESS != err_code)
         {
-            size_t len = index - 1;
+            size_t len = index;
             index = 0;
 
             do
@@ -273,6 +273,7 @@ rd_status_t app_uart_isr (ri_comm_evt_t evt,
             break;
 
         default:
+            // No action needed on connect/disconnect events.
             break;
     }
 

--- a/test/test_app_uart.c
+++ b/test/test_app_uart.c
@@ -452,7 +452,6 @@ void test_app_uart_parser_part_1_ok (void)
     rl_ringbuffer_dequeue_ExpectAnyArgsAndReturn (RL_SUCCESS);
     rl_ringbuffer_dequeue_ReturnMemThruPtr_data (&p_data_2, sizeof (uint8_t *));
     rl_ringbuffer_dequeue_ExpectAnyArgsAndReturn (RL_ERROR_NO_DATA);
-    re_ca_uart_payload_t payload_dec = {0};
     re_ca_uart_decode_ExpectAnyArgsAndReturn (RE_ERROR_DECODING_CRC);
     rl_ringbuffer_queue_ExpectAnyArgsAndReturn (RL_SUCCESS);
     rl_ringbuffer_queue_ExpectAnyArgsAndReturn (RL_SUCCESS);
@@ -494,7 +493,6 @@ void test_app_uart_parser_part_2_ok (void)
     rl_ringbuffer_dequeue_ExpectAnyArgsAndReturn (RL_SUCCESS);
     rl_ringbuffer_dequeue_ExpectAnyArgsAndReturn (RL_SUCCESS);
     rl_ringbuffer_dequeue_ExpectAnyArgsAndReturn (RL_ERROR_NO_DATA);
-    re_ca_uart_payload_t payload_dec = {0};
     re_ca_uart_decode_ExpectAnyArgsAndReturn (RD_SUCCESS);
     re_ca_uart_encode_ExpectAnyArgsAndReturn (RD_SUCCESS);
     ri_watchdog_feed_IgnoreAndReturn (RD_SUCCESS);

--- a/test/test_app_uart.c
+++ b/test/test_app_uart.c
@@ -443,30 +443,20 @@ void test_app_uart_parser_part_1_ok (void)
     re_ca_uart_decode_ExpectAndReturn ( (uint8_t *) &data_part1[0],
                                         (re_ca_uart_payload_t *) &payload, RE_ERROR_DECODING_CRC);
     rl_ringbuffer_queue_ExpectAnyArgsAndReturn (RL_SUCCESS);
-    
     rl_ringbuffer_queue_ExpectAnyArgsAndReturn (RL_SUCCESS);
-    
     rl_ringbuffer_queue_ExpectAnyArgsAndReturn (RL_SUCCESS);
-    
     rl_ringbuffer_dequeue_ExpectAnyArgsAndReturn (RL_SUCCESS);
-    
     rl_ringbuffer_dequeue_ReturnMemThruPtr_data (&p_data_0, sizeof (uint8_t *));
     rl_ringbuffer_dequeue_ExpectAnyArgsAndReturn (RL_SUCCESS);
-    
     rl_ringbuffer_dequeue_ReturnMemThruPtr_data (&p_data_1, sizeof (uint8_t *));
     rl_ringbuffer_dequeue_ExpectAnyArgsAndReturn (RL_SUCCESS);
-    
     rl_ringbuffer_dequeue_ReturnMemThruPtr_data (&p_data_2, sizeof (uint8_t *));
     rl_ringbuffer_dequeue_ExpectAnyArgsAndReturn (RL_ERROR_NO_DATA);
-    
     re_ca_uart_payload_t payload_dec = {0};
     re_ca_uart_decode_ExpectAnyArgsAndReturn (RE_ERROR_DECODING_CRC);
     rl_ringbuffer_queue_ExpectAnyArgsAndReturn (RL_SUCCESS);
-    
     rl_ringbuffer_queue_ExpectAnyArgsAndReturn (RL_SUCCESS);
-    
     rl_ringbuffer_queue_ExpectAnyArgsAndReturn (RL_SUCCESS);
-    
     ri_watchdog_feed_IgnoreAndReturn (RD_SUCCESS);
     app_uart_parser ( (void *) data_part1, 3);
     TEST_ASSERT (0 == mock_sends);
@@ -485,33 +475,25 @@ void test_app_uart_parser_part_2_ok (void)
                                             RD_SUCCESS);
     rd_error_check_ExpectAnyArgs();
     app_uart_isr (RI_COMM_RECEIVED,
-                  (void *) &data_part1[0], sizeof(data_part1));
+                  (void *) &data_part1[0], sizeof (data_part1));
     re_ca_uart_payload_t payload = {0};
     re_ca_uart_decode_ExpectAndReturn ( (uint8_t *) &data_part1[0],
                                         (re_ca_uart_payload_t *) &payload, RE_ERROR_DECODING_CRC);
-    for(size_t ii = 0; ii < sizeof(data_part1); ii++)
+
+    for (size_t ii = 0; ii < sizeof (data_part1); ii++)
     {
         rl_ringbuffer_queue_ExpectAnyArgsAndReturn (RL_SUCCESS);
     }
-    
+
     rl_ringbuffer_dequeue_ExpectAnyArgsAndReturn (RL_SUCCESS);
-    
     rl_ringbuffer_dequeue_ExpectAnyArgsAndReturn (RL_SUCCESS);
-    
     rl_ringbuffer_dequeue_ExpectAnyArgsAndReturn (RL_SUCCESS);
-    
     rl_ringbuffer_dequeue_ExpectAnyArgsAndReturn (RL_SUCCESS);
-    
     rl_ringbuffer_dequeue_ExpectAnyArgsAndReturn (RL_SUCCESS);
-    
     rl_ringbuffer_dequeue_ExpectAnyArgsAndReturn (RL_SUCCESS);
-    
     rl_ringbuffer_dequeue_ExpectAnyArgsAndReturn (RL_SUCCESS);
-    
     rl_ringbuffer_dequeue_ExpectAnyArgsAndReturn (RL_SUCCESS);
-    
     rl_ringbuffer_dequeue_ExpectAnyArgsAndReturn (RL_ERROR_NO_DATA);
-    
     re_ca_uart_payload_t payload_dec = {0};
     re_ca_uart_decode_ExpectAnyArgsAndReturn (RD_SUCCESS);
     re_ca_uart_encode_ExpectAnyArgsAndReturn (RD_SUCCESS);

--- a/test/test_app_uart.c
+++ b/test/test_app_uart.c
@@ -401,6 +401,9 @@ void test_app_uart_parser_part_1_ok (void)
         2 + CMD_IN_LEN,
         RE_CA_UART_SET_CH_37,
     };
+    uint8_t * p_data_0 = &data_part1[0];
+    uint8_t * p_data_1 = &data_part1[1];
+    uint8_t * p_data_2 = &data_part1[2];
     ri_scheduler_event_put_ExpectAndReturn (data_part1, 3, &app_uart_parser,
                                             RD_SUCCESS);
     rd_error_check_ExpectAnyArgs();
@@ -417,10 +420,13 @@ void test_app_uart_parser_part_1_ok (void)
     rl_ringbuffer_queue_ReturnThruPtr_buffer (&t_uart_ring_buffer);
     rl_ringbuffer_dequeue_ExpectAnyArgsAndReturn (RL_SUCCESS);
     rl_ringbuffer_dequeue_ReturnThruPtr_buffer (&t_uart_ring_buffer);
+    rl_ringbuffer_dequeue_ReturnMemThruPtr_data (&p_data_0, sizeof (uint8_t *));
     rl_ringbuffer_dequeue_ExpectAnyArgsAndReturn (RL_SUCCESS);
     rl_ringbuffer_dequeue_ReturnThruPtr_buffer (&t_uart_ring_buffer);
+    rl_ringbuffer_dequeue_ReturnMemThruPtr_data (&p_data_1, sizeof (uint8_t *));
     rl_ringbuffer_dequeue_ExpectAnyArgsAndReturn (RL_SUCCESS);
     rl_ringbuffer_dequeue_ReturnThruPtr_buffer (&t_uart_ring_buffer);
+    rl_ringbuffer_dequeue_ReturnMemThruPtr_data (&p_data_2, sizeof (uint8_t *));
     rl_ringbuffer_dequeue_ExpectAnyArgsAndReturn (RL_ERROR_NO_DATA);
     rl_ringbuffer_dequeue_ReturnThruPtr_buffer (&t_uart_ring_buffer);
     re_ca_uart_payload_t payload_dec = {0};

--- a/test/test_app_uart.c
+++ b/test/test_app_uart.c
@@ -385,7 +385,37 @@ void test_app_uart_parser_ok (void)
     re_ca_uart_payload_t payload = {0};
     re_ca_uart_decode_ExpectAndReturn ( (uint8_t *) &data[0],
                                         (re_ca_uart_payload_t *) &payload, RD_SUCCESS);
-    rl_ringbuffer_empty_ExpectAnyArgsAndReturn (true);
+    rl_ringbuffer_dequeue_ExpectAnyArgsAndReturn (RL_ERROR_NO_DATA);
+    re_ca_uart_encode_ExpectAnyArgsAndReturn (RD_SUCCESS);
+    ri_watchdog_feed_IgnoreAndReturn (RD_SUCCESS);
+    app_uart_parser ( (void *) data, 8);
+    TEST_ASSERT (1 == mock_sends);
+}
+
+void test_app_uart_parser_clean_old (void)
+{
+    uint8_t data[] =
+    {
+        RE_CA_UART_STX,
+        2 + CMD_IN_LEN,
+        RE_CA_UART_SET_CH_37,
+        0x01U,
+        RE_CA_UART_FIELD_DELIMITER,
+        0xB6U, 0x78U, //crc
+        RE_CA_UART_ETX
+    };
+    uint8_t * p_data_0 = &data[0];
+    ri_scheduler_event_put_ExpectAndReturn (data, 8, &app_uart_parser,
+                                            RD_SUCCESS);
+    rd_error_check_ExpectAnyArgs();
+    app_uart_isr (RI_COMM_RECEIVED,
+                  (void *) &data[0], 8);
+    re_ca_uart_payload_t payload = {0};
+    re_ca_uart_decode_ExpectAndReturn ( (uint8_t *) &data[0],
+                                        (re_ca_uart_payload_t *) &payload, RD_SUCCESS);
+    rl_ringbuffer_dequeue_ExpectAnyArgsAndReturn (RL_SUCCESS);
+    rl_ringbuffer_dequeue_ReturnMemThruPtr_data (&p_data_0, sizeof (uint8_t *));
+    rl_ringbuffer_dequeue_ExpectAnyArgsAndReturn (RL_ERROR_NO_DATA);
     re_ca_uart_encode_ExpectAnyArgsAndReturn (RD_SUCCESS);
     ri_watchdog_feed_IgnoreAndReturn (RD_SUCCESS);
     app_uart_parser ( (void *) data, 8);
@@ -413,30 +443,30 @@ void test_app_uart_parser_part_1_ok (void)
     re_ca_uart_decode_ExpectAndReturn ( (uint8_t *) &data_part1[0],
                                         (re_ca_uart_payload_t *) &payload, RE_ERROR_DECODING_CRC);
     rl_ringbuffer_queue_ExpectAnyArgsAndReturn (RL_SUCCESS);
-    rl_ringbuffer_queue_ReturnThruPtr_buffer (&t_uart_ring_buffer);
+    
     rl_ringbuffer_queue_ExpectAnyArgsAndReturn (RL_SUCCESS);
-    rl_ringbuffer_queue_ReturnThruPtr_buffer (&t_uart_ring_buffer);
+    
     rl_ringbuffer_queue_ExpectAnyArgsAndReturn (RL_SUCCESS);
-    rl_ringbuffer_queue_ReturnThruPtr_buffer (&t_uart_ring_buffer);
+    
     rl_ringbuffer_dequeue_ExpectAnyArgsAndReturn (RL_SUCCESS);
-    rl_ringbuffer_dequeue_ReturnThruPtr_buffer (&t_uart_ring_buffer);
+    
     rl_ringbuffer_dequeue_ReturnMemThruPtr_data (&p_data_0, sizeof (uint8_t *));
     rl_ringbuffer_dequeue_ExpectAnyArgsAndReturn (RL_SUCCESS);
-    rl_ringbuffer_dequeue_ReturnThruPtr_buffer (&t_uart_ring_buffer);
+    
     rl_ringbuffer_dequeue_ReturnMemThruPtr_data (&p_data_1, sizeof (uint8_t *));
     rl_ringbuffer_dequeue_ExpectAnyArgsAndReturn (RL_SUCCESS);
-    rl_ringbuffer_dequeue_ReturnThruPtr_buffer (&t_uart_ring_buffer);
+    
     rl_ringbuffer_dequeue_ReturnMemThruPtr_data (&p_data_2, sizeof (uint8_t *));
     rl_ringbuffer_dequeue_ExpectAnyArgsAndReturn (RL_ERROR_NO_DATA);
-    rl_ringbuffer_dequeue_ReturnThruPtr_buffer (&t_uart_ring_buffer);
+    
     re_ca_uart_payload_t payload_dec = {0};
     re_ca_uart_decode_ExpectAnyArgsAndReturn (RE_ERROR_DECODING_CRC);
     rl_ringbuffer_queue_ExpectAnyArgsAndReturn (RL_SUCCESS);
-    rl_ringbuffer_queue_ReturnThruPtr_buffer (&t_uart_ring_buffer);
+    
     rl_ringbuffer_queue_ExpectAnyArgsAndReturn (RL_SUCCESS);
-    rl_ringbuffer_queue_ReturnThruPtr_buffer (&t_uart_ring_buffer);
+    
     rl_ringbuffer_queue_ExpectAnyArgsAndReturn (RL_SUCCESS);
-    rl_ringbuffer_queue_ReturnThruPtr_buffer (&t_uart_ring_buffer);
+    
     ri_watchdog_feed_IgnoreAndReturn (RD_SUCCESS);
     app_uart_parser ( (void *) data_part1, 3);
     TEST_ASSERT (0 == mock_sends);
@@ -455,38 +485,33 @@ void test_app_uart_parser_part_2_ok (void)
                                             RD_SUCCESS);
     rd_error_check_ExpectAnyArgs();
     app_uart_isr (RI_COMM_RECEIVED,
-                  (void *) &data_part1[0], 5);
+                  (void *) &data_part1[0], sizeof(data_part1));
     re_ca_uart_payload_t payload = {0};
     re_ca_uart_decode_ExpectAndReturn ( (uint8_t *) &data_part1[0],
                                         (re_ca_uart_payload_t *) &payload, RE_ERROR_DECODING_CRC);
-    rl_ringbuffer_queue_ExpectAnyArgsAndReturn (RL_SUCCESS);
-    rl_ringbuffer_queue_ReturnThruPtr_buffer (&t_uart_ring_buffer);
-    rl_ringbuffer_queue_ExpectAnyArgsAndReturn (RL_SUCCESS);
-    rl_ringbuffer_queue_ReturnThruPtr_buffer (&t_uart_ring_buffer);
-    rl_ringbuffer_queue_ExpectAnyArgsAndReturn (RL_SUCCESS);
-    rl_ringbuffer_queue_ReturnThruPtr_buffer (&t_uart_ring_buffer);
-    rl_ringbuffer_queue_ExpectAnyArgsAndReturn (RL_SUCCESS);
-    rl_ringbuffer_queue_ReturnThruPtr_buffer (&t_uart_ring_buffer);
-    rl_ringbuffer_queue_ExpectAnyArgsAndReturn (RL_SUCCESS);
-    rl_ringbuffer_queue_ReturnThruPtr_buffer (&t_uart_ring_buffer);
+    for(size_t ii = 0; ii < sizeof(data_part1); ii++)
+    {
+        rl_ringbuffer_queue_ExpectAnyArgsAndReturn (RL_SUCCESS);
+    }
+    
     rl_ringbuffer_dequeue_ExpectAnyArgsAndReturn (RL_SUCCESS);
-    rl_ringbuffer_dequeue_ReturnThruPtr_buffer (&t_uart_ring_buffer);
+    
     rl_ringbuffer_dequeue_ExpectAnyArgsAndReturn (RL_SUCCESS);
-    rl_ringbuffer_dequeue_ReturnThruPtr_buffer (&t_uart_ring_buffer);
+    
     rl_ringbuffer_dequeue_ExpectAnyArgsAndReturn (RL_SUCCESS);
-    rl_ringbuffer_dequeue_ReturnThruPtr_buffer (&t_uart_ring_buffer);
+    
     rl_ringbuffer_dequeue_ExpectAnyArgsAndReturn (RL_SUCCESS);
-    rl_ringbuffer_dequeue_ReturnThruPtr_buffer (&t_uart_ring_buffer);
+    
     rl_ringbuffer_dequeue_ExpectAnyArgsAndReturn (RL_SUCCESS);
-    rl_ringbuffer_dequeue_ReturnThruPtr_buffer (&t_uart_ring_buffer);
+    
     rl_ringbuffer_dequeue_ExpectAnyArgsAndReturn (RL_SUCCESS);
-    rl_ringbuffer_dequeue_ReturnThruPtr_buffer (&t_uart_ring_buffer);
+    
     rl_ringbuffer_dequeue_ExpectAnyArgsAndReturn (RL_SUCCESS);
-    rl_ringbuffer_dequeue_ReturnThruPtr_buffer (&t_uart_ring_buffer);
+    
     rl_ringbuffer_dequeue_ExpectAnyArgsAndReturn (RL_SUCCESS);
-    rl_ringbuffer_dequeue_ReturnThruPtr_buffer (&t_uart_ring_buffer);
+    
     rl_ringbuffer_dequeue_ExpectAnyArgsAndReturn (RL_ERROR_NO_DATA);
-    rl_ringbuffer_dequeue_ReturnThruPtr_buffer (&t_uart_ring_buffer);
+    
     re_ca_uart_payload_t payload_dec = {0};
     re_ca_uart_decode_ExpectAnyArgsAndReturn (RD_SUCCESS);
     re_ca_uart_encode_ExpectAnyArgsAndReturn (RD_SUCCESS);

--- a/test/test_app_uart.c
+++ b/test/test_app_uart.c
@@ -225,7 +225,7 @@ void test_app_uart_parser_get_device_id_ok (void)
     re_ca_uart_decode_ExpectAndReturn ( (uint8_t *) &data[0],
                                         (re_ca_uart_payload_t *) &payload, RD_SUCCESS);
     re_ca_uart_decode_ReturnThruPtr_cmd ( (re_ca_uart_payload_t *) &expect_payload);
-    rl_ringbuffer_empty_ExpectAnyArgsAndReturn (true);
+    rl_ringbuffer_dequeue_ExpectAnyArgsAndReturn (RL_ERROR_NO_DATA);
     ri_radio_address_get_ExpectAnyArgsAndReturn (RD_SUCCESS);
     ri_comm_id_get_ExpectAnyArgsAndReturn (RD_SUCCESS);
     re_ca_uart_encode_ExpectAnyArgsAndReturn (RD_SUCCESS);


### PR DESCRIPTION
* Uses more recent Doxygen in GH actions to not error on README update.
* Checks the PVS Studio output in PVS Studio check.
  - All PVS Studio errors are reported, but only high-priority errors fail pull request.
* Fixes using undefined pointer values in case of dequeue being out of elements. 
  - Update to libraries to fix incorrect const qualifier on dequeue pointer. 
* Not tested on hardware, I can test Tuesday or Wednesday.
* Tests pass against master, #14 