### PR TITLE
ci: #73 Update github workflow actions and pin them to commit SHAs

### DIFF
--- a/.github/workflows/astyle.yml
+++ b/.github/workflows/astyle.yml
@@ -15,12 +15,12 @@ jobs:
   # This workflow contains a single job called "unit-test"
   astyle:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     # Install Artistic Style
     - name: Install Astyle

--- a/.github/workflows/build-fw.yml
+++ b/.github/workflows/build-fw.yml
@@ -10,17 +10,17 @@ on:
 jobs:
   build:
     name: Build firmware
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
           submodules: recursive
 
       - name: Set up Python 3.8
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: 3.8
 
@@ -38,7 +38,7 @@ jobs:
           rm -f ~/nrf-command-line-tools_10.24.2_amd64.deb
 
       - name: Install Arm GNU Toolchain (arm-none-eabi-gcc)
-        uses: carlosperate/arm-none-eabi-gcc-action@v1
+        uses: carlosperate/arm-none-eabi-gcc-action@98c40e51546516419841748d3210c290df0d2c6c # v1.13.0
         with:
           release: '7-2018-q2'
 
@@ -49,7 +49,7 @@ jobs:
 
       - name: Cache nRF5_SDK_15.3.0_59ac345
         id: cache-nRF5_SDK
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/nRF5_SDK_15.3.0_59ac345
           key: nRF5_SDK-${{ hashFiles('.github/workflows/build-fw.yml') }}
@@ -84,13 +84,13 @@ jobs:
           echo "app_hex=${BINNAME}_app.hex" >> $GITHUB_ENV
 
       - name: Upload artifact full.hex
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ env.full_hex }}
           path: src/targets/ruuvigw_nrf/${{ env.full_hex }}
 
       - name: Upload artifact app.hex
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ env.app_hex }}
           path: src/targets/ruuvigw_nrf/${{ env.app_hex }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -7,17 +7,19 @@ on:
 jobs:
   build:
     name: Build release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
           submodules: recursive
 
       - name: Set up Python 3.8
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: 3.8
 
@@ -35,7 +37,7 @@ jobs:
           rm -f ~/nrf-command-line-tools_10.24.2_amd64.deb
 
       - name: Install Arm GNU Toolchain (arm-none-eabi-gcc)
-        uses: carlosperate/arm-none-eabi-gcc-action@v1
+        uses: carlosperate/arm-none-eabi-gcc-action@98c40e51546516419841748d3210c290df0d2c6c # v1.13.0
         with:
           release: '7-2018-q2'
 
@@ -46,7 +48,7 @@ jobs:
 
       - name: Cache nRF5_SDK_15.3.0_59ac345
         id: cache-nRF5_SDK
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/nRF5_SDK_15.3.0_59ac345
           key: nRF5_SDK-${{ hashFiles('.github/workflows/build-fw.yml') }}
@@ -81,24 +83,44 @@ jobs:
           echo "app_hex=${BINNAME}_app.hex" >> $GITHUB_ENV
 
       - name: Upload artifact full.hex
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ env.full_hex }}
           path: src/targets/ruuvigw_nrf/${{ env.full_hex }}
 
       - name: Upload artifact app.hex
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ env.app_hex }}
           path: src/targets/ruuvigw_nrf/${{ env.app_hex }}
 
       - name: Create GitHub Release
-        id: create_release
-        uses: ncipollo/release-action@v1.14.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          draft: false
-          prerelease: true
-          generateReleaseNotes: true
-          artifacts: "src/targets/ruuvigw_nrf/${{ env.full_hex }},src/targets/ruuvigw_nrf/${{ env.app_hex }}"
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -xeuo pipefail
+          command -v gh >/dev/null 2>&1 || { echo "gh CLI not found"; exit 1; }
+          TAG="${{ env.git_version }}"
+          ASSETS=(
+            "src/targets/ruuvigw_nrf/${{ env.full_hex }}"
+            "src/targets/ruuvigw_nrf/${{ env.app_hex }}"
+          )
+          for asset in "${ASSETS[@]}"; do
+            if [ ! -f "$asset" ]; then
+              echo "Release asset not found: $asset" >&2
+              exit 1
+            fi
+          done
+          if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            if ! gh release create "$TAG" --repo "$GITHUB_REPOSITORY" \
+              --title "$TAG" --generate-notes --prerelease; then
+              echo "Create failed; rechecking..."
+              if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+                echo "Release still missing; aborting."
+                exit 1
+              fi
+            fi
+          fi
+          gh release upload "$TAG" "${ASSETS[@]}" \
+            --repo "$GITHUB_REPOSITORY" --clobber

--- a/.github/workflows/ceedling.yml
+++ b/.github/workflows/ceedling.yml
@@ -15,17 +15,17 @@ jobs:
   # This workflow contains a single job called "unit-test"
   unit-test:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         submodules: recursive
 
     - name: Set up Ruby 2.7
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
       with:
         ruby-version: '2.7'
 
@@ -35,7 +35,7 @@ jobs:
 
     - name: Cache nRF5_SDK_15.3.0_59ac345
       id: cache-nRF5_SDK
-      uses: actions/cache@v4
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: |
           ~/nRF5_SDK_15.3.0_59ac345
@@ -55,4 +55,3 @@ jobs:
         pwd
         ls -la
         make test_all
-

--- a/.github/workflows/gh-pages-check.yml
+++ b/.github/workflows/gh-pages-check.yml
@@ -13,12 +13,12 @@ jobs:
   # This workflow contains a single job called "build"
   doxygen:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         submodules: recursive
 

--- a/.github/workflows/gh-pages-push.yml
+++ b/.github/workflows/gh-pages-push.yml
@@ -13,12 +13,12 @@ jobs:
   # This workflow contains a single job called "build"
   doxygen:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         submodules: recursive
 
@@ -41,13 +41,13 @@ jobs:
           fi
 
     - name: Install SSH Client 🔑
-      uses: webfactory/ssh-agent@v0.5.2
+      uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
       with:
           ssh-private-key: ${{ secrets.DEPLOY_KEY }}
 
     # Deploy documents
     - name: Deploy to GitHub Pages
-      uses: JamesIves/github-pages-deploy-action@4.1.1
+      uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
       with:
           SSH: true
           BRANCH: gh-pages # The branch the action should deploy to.

--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -14,14 +14,14 @@ on:
 jobs:
   sonar-scan:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       BUILD_WRAPPER_OUT_DIR: bw_output # Directory where build-wrapper output will be placed
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         submodules: recursive
 
@@ -33,7 +33,7 @@ jobs:
         fi
 
     - name: Set up Ruby 2.7
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
       with:
         ruby-version: '2.7'
 
@@ -44,7 +44,7 @@ jobs:
         sudo pip install gcovr
 
     - name: Install Build Wrapper
-      uses: SonarSource/sonarqube-scan-action/install-build-wrapper@v6
+      uses: SonarSource/sonarqube-scan-action/install-build-wrapper@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
 
     # Runs a single command using the runners shell
     - name: Compile project
@@ -60,7 +60,7 @@ jobs:
         ls -la
 
     - name: SonarQube Scan
-      uses: SonarSource/sonarqube-scan-action@v6
+      uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Close #73
Pin GitHub Action versions to specific commit SHAs for enhanced security and reproducibility. Migrate `runs-on` runners from `ubuntu-latest` to `ubuntu-22.04` for consistent build environments. Modernize the release workflow in `build-release.yml` by replacing a third-party action with the native `gh` CLI.

| Repository                        |  Tag     |  Commit SHA                              |  Commit creation date   |
|-----------------------------------|----------|------------------------------------------|-------------------------|
| actions/checkout                  | v7.0.1   | 3d3c42e5aac5ba805825da76410c181273ba90b1 | 2026-07-17 18:45:11 UTC |
| actions/setup-python              | v7.0.0   | 5fda3b95a4ea91299a34e894583c3862153e4b97 | 2026-07-20 03:02:03 UTC |
| actions/cache                     | v6.1.0   | 55cc8345863c7cc4c66a329aec7e433d2d1c52a9 | 2026-06-23 20:30:28 UTC |
| actions/upload-artifact           | v7.0.1   | 043fb46d1a93c77aae656e7c1c64a875d1fc6a0a | 2026-04-10              |
| SonarSource/sonarqube-scan-action | v8.2.1   | 22918119ff8e1ca75a623e15c8296b6ea4fbe28f | 2026-07-13 15:36:59 UTC |
| ruby/setup-ruby                   | v1.321.0 | 95ef2b042f9d7a56d8268cba8559e2842e2ad01b | 2026-07-22 21:28:14 UTC |
| webfactory/ssh-agent              | v0.10.0  | e83874834305fe9a4a2997156cb26c5de65a8555 | 2026-03-11 15:15:28 UTC |
| JamesIves/github-pages-deploy-action | v4.8.0 | d92aa235d04922e8f08b40ce78cc5442fcfbfa2f | 2026-01-09 19:27:02 UTC |
| carlosperate/arm-none-eabi-gcc-action | v1.13.0 | 98c40e51546516419841748d3210c290df0d2c6c | 2026-07-06            |
